### PR TITLE
Flush after write

### DIFF
--- a/Serialize_Object/test.cpp
+++ b/Serialize_Object/test.cpp
@@ -16,6 +16,10 @@ class FooSerializerTest : public ::testing::Test {
             f2.serialize(output2);
             f3.serialize(output3);
 
+            output1.flush();
+            output2.flush();
+            output3.flush();
+
             input1.open("serialized_object1.bin", std::ios::binary);
             input2.open("serialized_object2.bin", std::ios::binary);
             input3.open("serialized_object3.bin", std::ios::binary);


### PR DESCRIPTION
The code was writing to the .bin files but not accounting for buffering that happens in the ostream.
So, the file would get created, we'd write some bytes into the output buffer, but those bytes wouldn't necessarily get written to disk.
Meanwhile, we'd open the files for reading but the files were still technically empty because the output buffers hadn't been flushed.